### PR TITLE
#14 Add support for inserting and updating VFP blank dates

### DIFF
--- a/Source/VfpEntityFrameworkProvider/VfpConsts.cs
+++ b/Source/VfpEntityFrameworkProvider/VfpConsts.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace VfpEntityFrameworkProvider
+{
+    public static class VfpConsts
+    {
+        public static readonly DateTime VfpBlankDate = new DateTime(1899, 12, 30);
+    }
+}

--- a/Source/VfpEntityFrameworkProvider/VfpEntityFrameworkProvider.csproj
+++ b/Source/VfpEntityFrameworkProvider/VfpEntityFrameworkProvider.csproj
@@ -199,6 +199,7 @@
     <Compile Include="TableIndexService.cs" />
     <Compile Include="TypeExtensions.cs" />
     <Compile Include="VfpConnectionFactory.cs" />
+    <Compile Include="VfpConsts.cs" />
     <Compile Include="VfpDbConfiguration.cs" />
     <Compile Include="VfpFunctions.cs" />
     <Compile Include="VfpMigrationSqlGenerator.cs" />

--- a/Source/VfpEntityFrameworkProvider/Visitors/SqlFormatter.cs
+++ b/Source/VfpEntityFrameworkProvider/Visitors/SqlFormatter.cs
@@ -522,7 +522,16 @@ namespace VfpEntityFrameworkProvider.Visitors {
                             Write(str);
                             break;
                         case TypeCode.DateTime:
-                            Write(string.Format("CTOT('{0:yyyy-MM-dd}T{0:HH:mm:ss}')", value));
+                            if ((DateTime)value != VfpConsts.VfpBlankDate)
+                            {
+                                Write(string.Format("CTOT('{0:yyyy-MM-dd}T{0:HH:mm:ss}')", value));
+                            }
+                            else
+                            {
+                                // Blank date support
+                                Write("CTOT('')");
+                            }
+
                             break;
                         case TypeCode.Object:
                             throw new NotSupportedException(string.Format("The constant for '{0}' is not supported", value));


### PR DESCRIPTION
The provider will insert blank date CTOT('') if property is set with 1899-12-30 date. I've made more detailed description in issue #14.